### PR TITLE
Fixed initial value warning if it is empty and not multiple.

### DIFF
--- a/src/FormsyDropdown.js
+++ b/src/FormsyDropdown.js
@@ -83,7 +83,7 @@ export default class FormsyDropdown extends Component {
       onChange: this.handleChange,
       onBlur: this.handleBlur,
       onClose: this.handleClose,
-      value: getValue() || defaultValue || multiple && [],
+      value: getValue() || defaultValue || multiple && [] || '',
       error,
       ...filterSuirElementProps(this.props),
     };


### PR DESCRIPTION
Removed in https://github.com/zabute/formsy-semantic-ui-react/commit/ee2f068ff3e5e6970fd9c90a7832403c9ba39978