### PR TITLE
Include 'node' PropType as one of label types

### DIFF
--- a/src/FormsyDropdown.js
+++ b/src/FormsyDropdown.js
@@ -27,7 +27,7 @@ class FormsyDropdown extends Component {
       ])),
     ]),
     required: PropTypes.bool,
-    label: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     errorLabel: PropTypes.element,
     isValid: PropTypes.func.isRequired,
     isPristine: PropTypes.func.isRequired,

--- a/src/FormsyInput.js
+++ b/src/FormsyInput.js
@@ -20,7 +20,7 @@ class FormsyInput extends Component {
     ]),
     errorLabel: PropTypes.element,
     required: PropTypes.bool,
-    label: PropTypes.string,
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     instantValidation: PropTypes.bool,
     defaultValue: PropTypes.string,
     onBlur: PropTypes.func,

--- a/test/FormsyDropdown.spec.js
+++ b/test/FormsyDropdown.spec.js
@@ -12,6 +12,7 @@ const TestForm = () => {
   return (
     <Form>
       <FormsyDropdown
+        label={<span>Clothing</span>}
         name="testInput"
         options={[
           { text: 'Hat', value: 'hat' },

--- a/test/FormsyInput.spec.js
+++ b/test/FormsyInput.spec.js
@@ -14,6 +14,7 @@ const TestForm = () => {
   return (
     <Form>
       <FormsyInput
+        label={<span>Email</span>}
         name="testInput"
         validations="isEmail"
         errorLabel={ errorLabel }

--- a/test/helpers.unit.js
+++ b/test/helpers.unit.js
@@ -1,0 +1,7 @@
+import sinon from 'sinon';
+
+sinon.stub(console, 'error', (warning) => {
+  if (typeof(warning) === 'string' && warning.indexOf('Warning: Failed prop type') > -1) {
+    throw new Error(warning);
+  }
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 process.env.NODE_ENV = 'test';
 
 require('babel-register')();
+require('./helpers.unit.js');
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 const jsdom = require('jsdom').jsdom;


### PR DESCRIPTION
This gets rid of warning message displayed by React when a node element is supplied as the value to label.

Fixes #27 