### PR TITLE
Fix default checked of Checkbox and Radio

### DIFF
--- a/src/FormsyCheckbox.js
+++ b/src/FormsyCheckbox.js
@@ -24,10 +24,12 @@ class FormsyCheckbox extends Component {
     getErrorMessage: PropTypes.func.isRequired,
     errorLabel: PropTypes.element,
     onChange: PropTypes.func,
+    checked: PropTypes.bool,
   }
 
   static defaultProps = {
     inputAs: Checkbox,
+    checked: false,
   }
 
   componentDidMount() {
@@ -49,7 +51,8 @@ class FormsyCheckbox extends Component {
       isPristine,
       errorLabel,
       getErrorMessage,
-      getValue,
+      defaultChecked,
+      checked,
       // Form.Field props
       as,
       width,
@@ -63,7 +66,7 @@ class FormsyCheckbox extends Component {
 
     const checkboxProps = {
       ...filterSuirElementProps(this.props),
-      checked: getValue(),
+      checked: checked || defaultChecked,
       onChange: this.handleChange,
     };
 


### PR DESCRIPTION
I use RadioGroup and try to set default checked prop, but it is not work.
For values of my Radio I use ["0", "1", ... ], so in FormsyCheckbox set { checked: "0" } and I get 
"Warning: Failed prop type: Invalid prop `checked` of type `string` supplied to `Checkbox`, expected `boolean`." and all Radio is checked in RadioGroup because FormsyCheckbox use string value for set bool "checked" prop.
