### PR TITLE
Pass dropdownProps to FormSelect

### DIFF
--- a/lib/FormsyDropdown.js
+++ b/lib/FormsyDropdown.js
@@ -240,7 +240,7 @@ var FormsyDropdown = function (_Component) {
           id: id
         });
 
-        var dropdownNode = shortHandMode ? (0, _react.createElement)(inputAs).props.control : inputAs;
+        var dropdownNode = shortHandMode ? (0, _react.createElement)(inputAs, dropdownProps).props.control : inputAs;
 
         return _react2['default'].createElement(
           _semanticUiReact.Form.Field,

--- a/src/FormsyDropdown.js
+++ b/src/FormsyDropdown.js
@@ -113,7 +113,7 @@ class FormsyDropdown extends Component {
       id,
     };
 
-    const dropdownNode = shortHandMode ? createElement(inputAs).props.control : inputAs;
+    const dropdownNode = shortHandMode ? createElement(inputAs, dropdownProps).props.control : inputAs;
 
     return (
       <Form.Field


### PR DESCRIPTION
Fixes https://github.com/zabute/formsy-semantic-ui-react/issues/50 by passing the missing props to the  SUIR `FormSelect`.