### PR TITLE
fix(Dropdown, Input): don't render label element if the label is empty

### DIFF
--- a/src/FormsyDropdown.js
+++ b/src/FormsyDropdown.js
@@ -125,7 +125,7 @@ class FormsyDropdown extends Component {
         inline={ inline }
         disabled={disabled}
       >
-        { shortHandMode && <label htmlFor={id}> { label } </label> }
+        { shortHandMode && label && <label htmlFor={id}> { label } </label> }
         { createElement(dropdownNode, { ...dropdownProps }) }
         { error && errorLabel && cloneElement(errorLabel, {}, getErrorMessage()) }
       </Form.Field>

--- a/src/FormsyInput.js
+++ b/src/FormsyInput.js
@@ -121,7 +121,7 @@ class FormsyInput extends Component {
         inline={ inline }
         disabled={disabled}
       >
-        { shortHandMode && <label htmlFor={id}> { label } </label> }
+        { shortHandMode && label && <label htmlFor={id}> { label } </label> }
         { createElement(inputNode, { ...inputProps }) }
         { !disabled && error && errorLabel && cloneElement(errorLabel, {}, getErrorMessage()) }
       </Form.Field>

--- a/test/Form.spec.js
+++ b/test/Form.spec.js
@@ -63,6 +63,32 @@ describe('<Form/>', () => {
       assert.equal(select.length, 1);
       assert.isTrue(select.is(FormsySelect));
     });
+
+    context('Layout structure', () => {
+      it('should render label for a Input', () => {
+        const wrapper = mountForm(<Form.Input name="input" label="input-label"/>);
+        const inputLabel = wrapper.find('label');
+        assert.equal(inputLabel.length, 1);
+      });
+
+      it('should not render label for a Input if none given', () => {
+        const wrapper = mountForm(<Form.Input name="input"/>);
+        const inputLabel = wrapper.find('label');
+        assert.equal(inputLabel.length, 0);
+      });
+
+      it('should render label for a DropDown', () => {
+        const wrapper = mountForm(<Form.Dropdown name="formInput" options={[]} label="drop-down-label"/>);
+        const inputLabel = wrapper.find('label');
+        assert.equal(inputLabel.length, 1);
+      });
+
+      it('should not render label for a DropDown', () => {
+        const wrapper = mountForm(<Form.Dropdown name="formInput" options={[]}/>);
+        const inputLabel = wrapper.find('label');
+        assert.equal(inputLabel.length, 0);
+      });
+    });
   });
 
   context('When Submitting', () => {


### PR DESCRIPTION
This fix not renders a `label` element if the label props is not provided.

`label` element inside `field` has margins, if the label is empty those margins are redundant.