### PR TITLE
fix(#58) - allow render Semantic-ui input as the input of FormsyInput

### DIFF
--- a/example/FormExamples.js
+++ b/example/FormExamples.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Form } from '../src';
-import { Label } from 'semantic-ui-react';
+import { Label, Input } from 'semantic-ui-react';
 
 const options = [
   { key: 'm', text: 'Male', value: 'male' },
@@ -57,6 +57,10 @@ export default class FormExamples extends Component {
         <Form.Group inline>
           <Form.Input name="phonePrefix" width={2} inline label="Phone" placeholder="+1" />
           <Form.Input name="phone" width={4} inline label="-" placeholder="000-000-0000" />
+        </Form.Group>
+
+        <Form.Group widths="equal">
+          <Form.Input name="email" label="Email" required inputAs={<Input label="@gmail.com" labelPosition="right" placeholder="John" />} />
         </Form.Group>
 
         <Form.RadioGroup

--- a/src/FormsyInput.js
+++ b/src/FormsyInput.js
@@ -1,6 +1,6 @@
-import React, { cloneElement, Component, createElement } from 'react';
+import React, { cloneElement, Component, createElement, isValidElement } from 'react';
 import { withFormsy } from 'formsy-react';
-import { Form, Input, TextArea } from 'semantic-ui-react';
+import { Form, Input } from 'semantic-ui-react';
 import { filterSuirElementProps } from './utils';
 import PropTypes from 'prop-types';
 
@@ -15,9 +15,7 @@ class FormsyInput extends Component {
     disabled: PropTypes.bool,
     inline: PropTypes.bool,
     passRequiredToField: PropTypes.bool,
-    inputAs: PropTypes.oneOf([
-      Input, TextArea, Form.Input, Form.TextArea,
-    ]),
+    inputAs: PropTypes.any,
     errorLabel: PropTypes.element,
     required: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -106,13 +104,19 @@ class FormsyInput extends Component {
       id,
     };
 
-    const shortHandMode = (inputAs === Form.Input || inputAs === Form.TextArea);
-    const inputNode = shortHandMode ? createElement(inputAs).props.control : inputAs;
+    const isFormField = (inputAs === Form.Input || inputAs === Form.TextArea);
+    const inputNode = isFormField ? createElement(inputAs).props.control : inputAs;
 
-    if (shortHandMode) {
+    if (isFormField) {
       delete inputProps.label;
       if (inputAs === Form.TextArea) delete inputProps.error;
     }
+
+    const inputElement = !isFormField && isValidElement(inputAs)
+      ? cloneElement(inputAs, { ...inputProps, ...inputAs.props })
+      : createElement(inputNode, { ...inputProps });
+
+    const shouldShowFormLabel = isFormField || isValidElement(inputAs);
 
     return (
       <Form.Field
@@ -124,8 +128,8 @@ class FormsyInput extends Component {
         inline={ inline }
         disabled={disabled}
       >
-        { shortHandMode && label && <label htmlFor={id}> { label } </label> }
-        { createElement(inputNode, { ...inputProps }) }
+        { shouldShowFormLabel && label && <label htmlFor={id}> { label } </label> }
+        { inputElement }
         { !disabled && error && errorLabel && cloneElement(errorLabel, {}, errorMessage) }
       </Form.Field>
     );

--- a/test/Form.spec.js
+++ b/test/Form.spec.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import Form from '../src/Form';
-import { Form as SemanticUIForm } from 'semantic-ui-react';
+import { Form as SemanticUIForm, Input } from 'semantic-ui-react';
 import FormsyInput from '../src/FormsyInput';
 import FormsyTextArea from '../src/FormsyTextArea';
 import FormsyCheckbox from '../src/FormsyCheckbox';
@@ -11,17 +11,17 @@ import FormsyDropdown from '../src/FormsyDropdown';
 import FormsySelect from '../src/FormsySelect';
 
 describe('<Form/>', () => {
+  const mountForm = (formElement) => {
+    const TestForm = () => <Form> { formElement } </Form>;
+    return mount(<TestForm/>);
+  };
+
   it('Renders Semantic-UI-React\'s Form', () => {
     const wrapper = mount(<Form> <Form.Input name="input"/> </Form>);
     assert.isDefined(wrapper.find(SemanticUIForm));
   });
 
   context('When using shorthands', () => {
-    const mountForm = (formElement) => {
-      const TestForm = () => <Form> { formElement } </Form>;
-      return mount(<TestForm/>);
-    };
-
     it('should render <Form.Input/> as <FormsyInput/>', () => {
       const wrapper = mountForm(<Form.Input name="input"/>);
       const input = wrapper.find(FormsyInput);
@@ -88,6 +88,20 @@ describe('<Form/>', () => {
         const inputLabel = wrapper.find('label');
         assert.equal(inputLabel.length, 0);
       });
+    });
+  });
+
+  context('When using custom inputAs', () => {
+    it('should allow render custom input', () => {
+      const wrapper = mountForm(<Form.Input name="input" label="form field"
+        inputAs={<Input label="prefix" />}
+      />);
+
+      const inputLabel = wrapper.find('.field > label');
+      assert.equal(inputLabel.text().trim(), 'form field');
+
+      const prefixLabel = wrapper.find('.ui.label.label');
+      assert.equal(prefixLabel.text().trim(), 'prefix');
     });
   });
 

--- a/test/FormsyInput.spec.js
+++ b/test/FormsyInput.spec.js
@@ -46,6 +46,13 @@ describe('<Input/>', () => {
     assert.ok(mount(<TestForm />).find(FormsyInput).find('Input').is(Input));
   });
 
+  context('Layout structure', () => {
+    it('should not render form label', () => {
+      const formLabel = wrapper.find('.field > label');
+      assert.equal(formLabel.length, 0);
+    });
+  });
+
   context('When value is invalid', () => {
     beforeEach(() => {
       wrapper = mount(<TestForm value={invalidValue} />);


### PR DESCRIPTION
This PR allows pass any preconfigured SUIR input to the `Form.Input` formsy component.
It allows to generate inputs like this:
![image](https://user-images.githubusercontent.com/9304194/57970818-dfe2a400-798e-11e9-9417-80bed2feda70.png)
by using this markup
```javascript
<Form.Input
  name="email"
  label="Email"
  required
  inputAs={<Input label="@gmail.com" labelPosition="right" placeholder="John" />}
/>;
```

* I've added a test for the reason why we need the [`shortHandMode` check](https://github.com/zabute/formsy-semantic-ui-react/blob/b97337732fe97c9aca9da5c6cbe96d1fc407fd3f/src/FormsyInput.js#L124).