### PR TITLE
fix(#58) - allow render Semantic-ui input as the input of FormsyInput

### DIFF
--- a/example/FormExamples.js
+++ b/example/FormExamples.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Form } from '../src';
-import { Label } from 'semantic-ui-react';
+import { Label, Input } from 'semantic-ui-react';
 
 const options = [
   { key: 'm', text: 'Male', value: 'male' },
@@ -57,6 +57,10 @@ export default class FormExamples extends Component {
         <Form.Group inline>
           <Form.Input name="phonePrefix" width={2} inline label="Phone" placeholder="+1" />
           <Form.Input name="phone" width={4} inline label="-" placeholder="000-000-0000" />
+        </Form.Group>
+
+        <Form.Group widths="equal">
+          <Form.Input name="email" label="Email" required inputAs={<Input label="@gmail.com" labelPosition="right" placeholder="John" />} />
         </Form.Group>
 
         <Form.RadioGroup

--- a/lib/FormsyInput.js
+++ b/lib/FormsyInput.js
@@ -118,13 +118,17 @@ var FormsyInput = function (_Component) {
           id: id
         });
 
-        var shortHandMode = inputAs === _semanticUiReact.Form.Input || inputAs === _semanticUiReact.Form.TextArea;
-        var inputNode = shortHandMode ? (0, _react.createElement)(inputAs).props.control : inputAs;
+        var isFormField = inputAs === _semanticUiReact.Form.Input || inputAs === _semanticUiReact.Form.TextArea;
+        var inputNode = isFormField ? (0, _react.createElement)(inputAs).props.control : inputAs;
 
-        if (shortHandMode) {
+        if (isFormField) {
           delete inputProps.label;
           if (inputAs === _semanticUiReact.Form.TextArea) delete inputProps.error;
         }
+
+        var inputElement = !isFormField && (0, _react.isValidElement)(inputAs) ? (0, _react.cloneElement)(inputAs, _extends({}, inputProps, inputAs.props)) : (0, _react.createElement)(inputNode, _extends({}, inputProps));
+
+        var shouldShowFormLabel = isFormField || (0, _react.isValidElement)(inputAs);
 
         return _react2['default'].createElement(
           _semanticUiReact.Form.Field,
@@ -137,14 +141,14 @@ var FormsyInput = function (_Component) {
             inline: inline,
             disabled: disabled
           },
-          shortHandMode && label && _react2['default'].createElement(
+          shouldShowFormLabel && label && _react2['default'].createElement(
             'label',
             { htmlFor: id },
             ' ',
             label,
             ' '
           ),
-          (0, _react.createElement)(inputNode, _extends({}, inputProps)),
+          inputElement,
           !disabled && error && errorLabel && (0, _react.cloneElement)(errorLabel, {}, errorMessage)
         );
       }
@@ -166,7 +170,7 @@ FormsyInput.propTypes = {
   disabled: _propTypes2['default'].bool,
   inline: _propTypes2['default'].bool,
   passRequiredToField: _propTypes2['default'].bool,
-  inputAs: _propTypes2['default'].oneOf([_semanticUiReact.Input, _semanticUiReact.TextArea, _semanticUiReact.Form.Input, _semanticUiReact.Form.TextArea]),
+  inputAs: _propTypes2['default'].any,
   errorLabel: _propTypes2['default'].element,
   required: _propTypes2['default'].bool,
   label: _propTypes2['default'].oneOfType([_propTypes2['default'].string, _propTypes2['default'].node]),

--- a/src/FormsyInput.js
+++ b/src/FormsyInput.js
@@ -1,6 +1,6 @@
-import React, { cloneElement, Component, createElement } from 'react';
+import React, { cloneElement, Component, createElement, isValidElement } from 'react';
 import { withFormsy } from 'formsy-react';
-import { Form, Input, TextArea } from 'semantic-ui-react';
+import { Form, Input } from 'semantic-ui-react';
 import { filterSuirElementProps } from './utils';
 import PropTypes from 'prop-types';
 
@@ -15,9 +15,7 @@ class FormsyInput extends Component {
     disabled: PropTypes.bool,
     inline: PropTypes.bool,
     passRequiredToField: PropTypes.bool,
-    inputAs: PropTypes.oneOf([
-      Input, TextArea, Form.Input, Form.TextArea,
-    ]),
+    inputAs: PropTypes.any,
     errorLabel: PropTypes.element,
     required: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -106,13 +104,19 @@ class FormsyInput extends Component {
       id,
     };
 
-    const shortHandMode = (inputAs === Form.Input || inputAs === Form.TextArea);
-    const inputNode = shortHandMode ? createElement(inputAs).props.control : inputAs;
+    const isFormField = (inputAs === Form.Input || inputAs === Form.TextArea);
+    const inputNode = isFormField ? createElement(inputAs).props.control : inputAs;
 
-    if (shortHandMode) {
+    if (isFormField) {
       delete inputProps.label;
       if (inputAs === Form.TextArea) delete inputProps.error;
     }
+
+    const inputElement = !isFormField && isValidElement(inputAs)
+      ? cloneElement(inputAs, { ...inputProps, ...inputAs.props })
+      : createElement(inputNode, { ...inputProps });
+
+    const shouldShowFormLabel = isFormField || isValidElement(inputAs);
 
     return (
       <Form.Field
@@ -124,8 +128,8 @@ class FormsyInput extends Component {
         inline={ inline }
         disabled={disabled}
       >
-        { shortHandMode && label && <label htmlFor={id}> { label } </label> }
-        { createElement(inputNode, { ...inputProps }) }
+        { shouldShowFormLabel && label && <label htmlFor={id}> { label } </label> }
+        { inputElement }
         { !disabled && error && errorLabel && cloneElement(errorLabel, {}, errorMessage) }
       </Form.Field>
     );

--- a/test/Form.spec.js
+++ b/test/Form.spec.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import Form from '../src/Form';
-import { Form as SemanticUIForm } from 'semantic-ui-react';
+import { Form as SemanticUIForm, Input } from 'semantic-ui-react';
 import FormsyInput from '../src/FormsyInput';
 import FormsyTextArea from '../src/FormsyTextArea';
 import FormsyCheckbox from '../src/FormsyCheckbox';
@@ -11,17 +11,17 @@ import FormsyDropdown from '../src/FormsyDropdown';
 import FormsySelect from '../src/FormsySelect';
 
 describe('<Form/>', () => {
+  const mountForm = (formElement) => {
+    const TestForm = () => <Form> { formElement } </Form>;
+    return mount(<TestForm/>);
+  };
+
   it('Renders Semantic-UI-React\'s Form', () => {
     const wrapper = mount(<Form> <Form.Input name="input"/> </Form>);
     assert.isDefined(wrapper.find(SemanticUIForm));
   });
 
   context('When using shorthands', () => {
-    const mountForm = (formElement) => {
-      const TestForm = () => <Form> { formElement } </Form>;
-      return mount(<TestForm/>);
-    };
-
     it('should render <Form.Input/> as <FormsyInput/>', () => {
       const wrapper = mountForm(<Form.Input name="input"/>);
       const input = wrapper.find(FormsyInput);
@@ -88,6 +88,20 @@ describe('<Form/>', () => {
         const inputLabel = wrapper.find('label');
         assert.equal(inputLabel.length, 0);
       });
+    });
+  });
+
+  context('When using custom inputAs', () => {
+    it('should allow render custom input', () => {
+      const wrapper = mountForm(<Form.Input name="input" label="form field"
+        inputAs={<Input label="prefix" />}
+      />);
+
+      const inputLabel = wrapper.find('.field > label');
+      assert.equal(inputLabel.text().trim(), 'form field');
+
+      const prefixLabel = wrapper.find('.ui.label.label');
+      assert.equal(prefixLabel.text().trim(), 'prefix');
     });
   });
 

--- a/test/FormsyInput.spec.js
+++ b/test/FormsyInput.spec.js
@@ -46,6 +46,13 @@ describe('<Input/>', () => {
     assert.ok(mount(<TestForm />).find(FormsyInput).find('Input').is(Input));
   });
 
+  context('Layout structure', () => {
+    it('should not render form label', () => {
+      const formLabel = wrapper.find('.field > label');
+      assert.equal(formLabel.length, 0);
+    });
+  });
+
   context('When value is invalid', () => {
     beforeEach(() => {
       wrapper = mount(<TestForm value={invalidValue} />);


### PR DESCRIPTION
This is the same PR of https://github.com/zabute/formsy-semantic-ui-react/pull/60
Just added missing files 